### PR TITLE
Update iOS deployment target to 9.0 for Xcode 12

### DIFF
--- a/HTTPParserC.podspec
+++ b/HTTPParserC.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'HTTPParserC'
-  s.version = '2.9.2'
+  s.version = '2.10.0'
   s.license = 'MIT'
 
   s.summary = 'HTTP message parser written in C'
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'SWIFT_INCLUDE_PATHS' => '$(SRCROOT)/HTTPParserC/Sources/**' }
   s.requires_arc = false
 
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
   s.osx.deployment_target = '10.6'

--- a/HTTPParserC.xcodeproj/project.pbxproj
+++ b/HTTPParserC.xcodeproj/project.pbxproj
@@ -155,7 +155,7 @@
 		OBJ_15 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -166,10 +166,10 @@
 					"$(SRCROOT)/Sources/HTTPParserC/include",
 				);
 				INFOPLIST_FILE = HTTPParserC.xcodeproj/HTTPParserC_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MARKETING_VERSION = 2.9.2;
+				MARKETING_VERSION = 2.10.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -187,7 +187,7 @@
 		OBJ_16 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -198,10 +198,10 @@
 					"$(SRCROOT)/Sources/HTTPParserC/include",
 				);
 				INFOPLIST_FILE = HTTPParserC.xcodeproj/HTTPParserC_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MARKETING_VERSION = 2.9.2;
+				MARKETING_VERSION = 2.10.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "HTTPParserC",
     platforms: [
-        .iOS(.v8),
+        .iOS(.v9),
         .tvOS(.v9),
         .macOS(.v10_10),
         .watchOS(.v2)


### PR DESCRIPTION
Similar to [this PR](https://github.com/Building42/Telegraph/pull/103) in the Telegraph repo I propose incrementing the iOS deployment target to 9.0 to get rid of some annoying warnings.

I also adapted the podspec and other parts with a new version number (2.10.0) as this might be a breaking change for some people. The rest is self-explanatory I guess. 😄 